### PR TITLE
Update documentation for timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note: **all environment variables are mandatory** and must be set via [`docker-c
 | `AGENDAV_FOOTER`        | `"Hosted by Example Company"`         |
 | `AGENDAV_ENC_KEY`       | `my_encrypt10n_k3y`                   |
 | `AGENDAV_CALDAV_SERVER` | `https://baikal.example.com/cal.php`  |
-| `AGENDAV_TIMEZONE`      | `UTC`                                 |
+| `AGENDAV_TIMEZONE`      | `UTC`, `UTC+1`, `Europe/Berlin`       |
 | `AGENDAV_LANG`          | `en`                                  |
 | `AGENDAV_LOG_DIR`       | `/tmp/`                               |
 


### PR DESCRIPTION
When using this image it was not sure which timezone formats are supported, only UTC offsets or also the tz codes. Because I live in germany where we have dailight savings time it's important to be able to use the tz codes because with only UTC offsets I would have to switch between UTC+1 and UTC+2 twice a year, whereas Europe/Berlin has DST already included. 

I found out through just trying that tz codes are indeed supported and think that it could save a few steps researching if the documentation already includes the different supported versions