### PR TITLE
Two bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && \
     apt-get -y install \
         apache2 \
         php5.6 \
+        php5.6-mbstring \
         php5.6-xml \
         php5.6-mysql && \
     apt-get install nano && \

--- a/README.md
+++ b/README.md
@@ -16,16 +16,17 @@ See [packages](https://ghcr.io/nagimov/agendav-docker)
 
 Note: **all environment variables are mandatory** and must be set via [`docker-compose.yml`](https://github.com/nagimov/agendav-docker/blob/master/docker-compose.yml) or via `-e` option of `docker run ...`
 
-| Environment Variable    | Example                               |
-| ----------------------- | ------------------------------------- |
-| `AGENDAV_SERVER_NAME`   | `127.0.0.1`                           |
-| `AGENDAV_TITLE`         | `"Welcome to Example Agendav Server"` |
-| `AGENDAV_FOOTER`        | `"Hosted by Example Company"`         |
-| `AGENDAV_ENC_KEY`       | `my_encrypt10n_k3y`                   |
-| `AGENDAV_CALDAV_SERVER` | `https://baikal.example.com/cal.php`  |
-| `AGENDAV_TIMEZONE`      | `UTC`, `UTC+1`, `Europe/Berlin`       |
-| `AGENDAV_LANG`          | `en`                                  |
-| `AGENDAV_LOG_DIR`       | `/tmp/`                               |
+| Environment Variable        | Example                               |
+| --------------------------- | ------------------------------------- |
+| `AGENDAV_SERVER_NAME`       | `127.0.0.1`                           |
+| `AGENDAV_TITLE`             | `"Welcome to Example Agendav Server"` |
+| `AGENDAV_FOOTER`            | `"Hosted by Example Company"`         |
+| `AGENDAV_ENC_KEY`           | `my_encrypt10n_k3y`                   |
+| `AGENDAV_CALDAV_SERVER`     | `https://baikal.example.com/cal.php`  |
+| `AGENDAV_CALDAV_PUBLIC_URL` | `https://baikal.example.com`          |
+| `AGENDAV_TIMEZONE`          | `UTC`, `UTC+1`, `Europe/Berlin`       |
+| `AGENDAV_LANG`              | `en`                                  |
+| `AGENDAV_LOG_DIR`           | `/tmp/`                               |
 
 ## Deployment
 
@@ -40,6 +41,7 @@ docker run -d --name=agendav \
     -e AGENDAV_FOOTER="Hosted by Example Company" \
     -e AGENDAV_ENC_KEY=my_encrypt10n_k3y \
     -e AGENDAV_CALDAV_SERVER=https://baikal.example.com/cal.php \
+    -e AGENDAV_CALDAV_PUBLIC_URL=https://baikal.example.com \
     -e AGENDAV_TIMEZONE=UTC \
     -e AGENDAV_LANG=en \
     -e AGENDAV_LOG_DIR=/tmp/ \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - AGENDAV_FOOTER=Hosted by Example Company
       - AGENDAV_ENC_KEY=my_encrypt10n_k3y
       - AGENDAV_CALDAV_SERVER=https://baikal.example.com/cal.php
+      - AGENDAV_CALDAV_PUBLIC_URL=https://baikal.example.com
       - AGENDAV_TIMEZONE=UTC
       - AGENDAV_LANG=en
       - AGENDAV_LOG_DIR=/tmp/

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,7 @@ sed -i -e "s/AGENDAV_TITLE/$( echo "${AGENDAV_TITLE}" | sed -e 's/[\/}]/\\&/g')/
 sed -i -e "s/AGENDAV_FOOTER/$( echo "${AGENDAV_FOOTER}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_ENC_KEY/$( echo "${AGENDAV_ENC_KEY}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_CALDAV_SERVER/$( echo "${AGENDAV_CALDAV_SERVER}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
+sed -i -e "s/AGENDAV_CALDAV_PUBLIC_URL/$( echo "${AGENDAV_CALDAV_PUBLIC_URL:-$AGENDAV_CALDAV_SERVER}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/UTC/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_LANG/$( echo "${AGENDAV_LANG}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_LOG_DIR/$( echo "${AGENDAV_LOG_DIR}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}

--- a/settings.php
+++ b/settings.php
@@ -26,7 +26,7 @@ $app['caldav.authmethod'] = 'basic';
 // Whether to show public CalDAV urls
 $app['caldav.publicurls'] = true;
 // Whether to show public CalDAV urls
-$app['caldav.baseurl.public'] = 'AGENDAV_CALDAV_SERVER';
+$app['caldav.baseurl.public'] = 'AGENDAV_CALDAV_PUBLIC_URL';
 // Default timezone
 $app['defaults.timezone'] = 'AGENDAV_TIMEZONE';
 // Default languajge


### PR DESCRIPTION
Hello ! 

Here is a PR with two fixes. The first one allows long, multi-line descriptions - without php5.6-mbstring installed, a paragraph-long description makes the event unsavable, with the following error :

```PHP Fatal error:  Call to undefined function Sabre\\VObject\\mb_strcut() in /var/www/agendav/web/vendor/sabre/vobject/lib/Property.php on line 252,```

The second one adds an environment variable for the caldav.baseurl.public Agendav variable, with fixes the "Calendar URL for CalDAV clients" link that we can find when clicking the cogs at the right of a calendar.
By default, it falls back to the existing variable, so as not to break existing deployments.

Hope this helps,
