### PR TITLE
Dockerfile Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.2
 
 FROM debian:bullseye-slim as downloader
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ COPY pre-env.sh /tmp/pre-env.sh
 ADD https://curl.se/ca/cacert.pem /etc/ssl/certs/
 
 RUN chmod +x /tmp/pre-env.sh && \
+    chown -R www-data:www-data ${PHP_INI_DIR} && \
+    chown -R www-data:www-data /var/run/apache2 && \
+    echo "Listen 8080" > /etc/apache2/ports.conf && \
     cp ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini && \
     echo 'date.timezone = "AGENDAV_TIMEZONE"' >> ${PHP_INI_DIR}/php.ini && \
     echo 'magic_quotes_runtime = false' >> ${PHP_INI_DIR}/php.ini && \
@@ -69,7 +72,9 @@ RUN ln -sf /dev/stdout /var/log/apache2/access.log \
     && ln -sf /dev/stderr /var/log/apache2/error.log \
     && ln -sf /dev/stderr /var/log/apache2/davi-error.log
 
-EXPOSE 80
+EXPOSE 8080
+
+USER www-data
 
 ENTRYPOINT ["/usr/local/bin/run.sh"]
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # agendav-docker
 
-Docker image for [AgenDAV - CalDAV web client](https://github.com/agendav/agendav). AgenDAV requires a CalDAV server running alongside (Baïkal, DAViCal, etc.). The address of CalDAV server must be specified in `AGENDAV_CALDAV_SERVER` env, e.g. `AGENDAV_CALDAV_SERVER=https://baikal.server.com/cal.php`
+Docker image for [AgenDAV - CalDAV web client](https://github.com/agendav/agendav). AgenDAV requires a CalDAV server running alongside (Baïkal, DAViCal, etc.). The address of CalDAV server must be specified in `AGENDAV_CALDAV_SERVER` env, e.g. `AGENDAV_CALDAV_SERVER=https://baikal.server.com/cal.php` or `AGENDAV_CALDAV_SERVER=https://radicale.server.svc.com:5232/%u`
 
 **Note regarding use of Baïkal back-end**: `WebDAV authentication type` must be set to `Basic` during Baïkal initialization.
 
 Since this image only carries a front-end for CalDAV, there's no provision for persistency. Running agendav statelessly has no drawbacks since agendav itself is not customizable.
 
-Standard `debian` base image is used. The build is not optimized for size or compilation time.
+Standard `php:apache` base image is used. The build is not optimized for size or compilation time.
 
 ## Supported tags
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Note: **all environment variables are mandatory** and must be set via [`docker-c
 ```
 docker pull ghcr.io/nagimov/agendav-docker:latest
 docker run -d --name=agendav \
-    -p 80:80 \
+    -p 80:8080 \
     -e AGENDAV_SERVER_NAME=127.0.0.1 \
     -e AGENDAV_TITLE="Welcome to Example Agendav Server" \
     -e AGENDAV_FOOTER="Hosted by Example Company" \

--- a/agendav.conf
+++ b/agendav.conf
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost *:8080>
 	DocumentRoot /var/www/agendav/web/public
 	ServerName ${AGENDAV_SERVER_NAME}
 	ErrorLog ${APACHE_LOG_DIR}/davi-error.log

--- a/pre-env.sh
+++ b/pre-env.sh
@@ -5,7 +5,5 @@ sed -i -e "s/AGENDAV_DB_NAME/$( echo "${AGENDAV_DB_NAME}" | sed -e 's/[\/}]/\\&/
 sed -i -e "s/AGENDAV_DB_USER/$( echo "${AGENDAV_DB_USER}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_DB_PASSWORD/$( echo "${AGENDAV_DB_PASSWORD}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_TIMEZONE/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
-CONFIG_FILE="/etc/php/5.6/cli/php.ini"
-sed -i -e "s/AGENDAV_TIMEZONE/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
-CONFIG_FILE="/etc/php/5.6/apache2/php.ini"
+CONFIG_FILE="${PHP_INI_DIR}/php.ini"
 sed -i -e "s/AGENDAV_TIMEZONE/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}

--- a/run.sh
+++ b/run.sh
@@ -9,9 +9,7 @@ sed -i -e "s/AGENDAV_CALDAV_PUBLIC_URL/$( echo "${AGENDAV_CALDAV_PUBLIC_URL:-$AG
 sed -i -e "s/UTC/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_LANG/$( echo "${AGENDAV_LANG}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_LOG_DIR/$( echo "${AGENDAV_LOG_DIR}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
-CONFIG_FILE="/etc/php/5.6/cli/php.ini"
-sed -i -e "s/UTC/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
-CONFIG_FILE="/etc/php/5.6/apache2/php.ini"
+CONFIG_FILE="${PHP_INI_DIR}/php.ini"
 sed -i -e "s/UTC/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 
 

--- a/run.sh
+++ b/run.sh
@@ -12,9 +12,6 @@ sed -i -e "s/AGENDAV_LOG_DIR/$( echo "${AGENDAV_LOG_DIR}" | sed -e 's/[\/}]/\\&/
 CONFIG_FILE="${PHP_INI_DIR}/php.ini"
 sed -i -e "s/UTC/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 
-
-find /var/lib/mysql/mysql -exec touch -c -a {} +
-service mariadb restart
 if [ "x$1" = 'xapache2' ]; then
 	echo "Start webserver"
 	exec /usr/sbin/apache2ctl -D FOREGROUND

--- a/settings.php
+++ b/settings.php
@@ -9,11 +9,8 @@ $app['site.footer'] = 'AGENDAV_FOOTER';
 $app['proxies'] = [];
 // Database settings
 $app['db.options'] = [
-    	'dbname' => 'AGENDAV_DB_NAME',
-        'user' => 'AGENDAV_DB_USER',
-        'password' => 'AGENDAV_DB_PASSWORD',
-    	'host' => '127.0.0.1',
-    	'driver' => 'pdo_mysql',
+    	'path' => '/var/agendav/db.sqlite',
+    	'driver' => 'pdo_sqlite',
 ];
 // Encryption key
 $app['encryption.key'] = 'AGENDAV_ENC_KEY';


### PR DESCRIPTION
Updates the version of PHP and AgenDAV used, swaps to sqlite, sets the user command and starts running on port 8080 to reduce required privileges.

I've tried to keep commits isolated, so potentially it could be split up into different PRs, but grouped them together for now as this gets the image into a more secure state.

## Commits

* feat: update to php 7.4 and upgrade version - swaps to the [Docker PHP image](https://hub.docker.com/_/php) for 7.4. This was the latest version of PHP that would work with the mysql migrations. Note that 7.4 is still EOL.
* chore: clean up image build - trying to slim the image size a bit
* feat: change to sqlite - avoids running a second service in the background, for a stateless environment most likely powerful enough to avoid performance issues, allows upgrading PHP further
* update: php version to 8.2 - update to 8.2, which works with the sqlite driver. Possibly a different mysql driver would also work with this
* feat : set user to www-data and start using port 8080 - removes root and reduces privileges required to run the container