### PR TITLE
Change exposed Port to 8080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,4 @@ services:
       - AGENDAV_LANG=en
       - AGENDAV_LOG_DIR=/tmp/
     ports:
-      - "80:80"
+      - "80:8080"


### PR DESCRIPTION
I tried updating the Container and got a 502 from my reverse proxy. I figured that the port needs to be changed to 80:8080 to reflect the exposed port of the docker container.