### PR TITLE
Fix Log Permission Issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: login to ${{ env.REGISTRY }}
         uses: docker/login-action@v2
@@ -41,7 +41,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ RUN chmod +x /tmp/pre-env.sh && \
     chmod 644 /etc/ssl/certs/cacert.pem && \
     chown -R www-data:www-data ${PHP_INI_DIR} && \
     chown -R www-data:www-data /var/run/apache2 && \
-    echo "Listen 8080" > /etc/apache2/ports.conf && \
+    chmod 755 ${APACHE_LOG_DIR} && \
+    chown -R www-data:www-data ${APACHE_LOG_DIR} && \
     cp ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini && \
     echo 'date.timezone = "AGENDAV_TIMEZONE"' >> ${PHP_INI_DIR}/php.ini && \
     echo 'magic_quotes_runtime = false' >> ${PHP_INI_DIR}/php.ini && \
@@ -66,12 +67,14 @@ RUN chmod +x /tmp/pre-env.sh && \
     a2ensite agendav.conf && \
     a2dissite 000-default && \
     a2enmod rewrite && \
+    echo "Listen 127.0.0.1:8080" > /etc/apache2/ports.conf && \
     service apache2 restart && \
-    service apache2 stop
+    service apache2 stop &&  \
+    echo "Listen 8080" > /etc/apache2/ports.conf
 
-RUN ln -sf /dev/stdout /var/log/apache2/access.log \
-    && ln -sf /dev/stderr /var/log/apache2/error.log \
-    && ln -sf /dev/stderr /var/log/apache2/davi-error.log
+RUN ln -sf /dev/stdout ${APACHE_LOG_DIR}/access.log \
+    && ln -sf /dev/stderr ${APACHE_LOG_DIR}/error.log \
+    && ln -sf /dev/stderr ${APACHE_LOG_DIR}/davi-error.log
 
 EXPOSE 8080
 


### PR DESCRIPTION
Fixes https://github.com/nagimov/agendav-docker/issues/17

For some reason `GITHUB_TOKEN` would not work on my build, successful builds were run with a PAT - I'm guessing this was a transient issue so I removed the commit referencing that. I made some other updates to the workflow while trying to resolve it.

## Changes

* set owner and permissions on apache log directory
* bind only to localhost during build (this should avoid the occasional build failures where it cannot bind to 0.0.0.0:8080)
* update actions in workflow