### PR TITLE
Fix permissions on mounted settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,9 @@ RUN chmod +x /tmp/pre-env.sh && \
     service apache2 stop &&  \
     echo "Listen 8080" > /etc/apache2/ports.conf
 
+RUN chown www-data:www-data /var/www/agendav/web/config/settings.php
+RUN chown www-data:www-data ${PHP_INI_DIR}/php.ini
+
 RUN ln -sf /dev/stdout ${APACHE_LOG_DIR}/access.log \
     && ln -sf /dev/stderr ${APACHE_LOG_DIR}/error.log \
     && ln -sf /dev/stderr ${APACHE_LOG_DIR}/davi-error.log

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
-CONFIG_FILE="/var/www/agendav/web/config/settings.php"
+CONFIG_FILE="/var/www/agendav/web/config/settings.php.tmp"
+CONFIG_FILE_REAL="/var/www/agendav/web/config/settings.php"
+
+cp $CONFIG_FILE_REAL $CONFIG_FILE
 sed -i -e "s/AGENDAV_TITLE/$( echo "${AGENDAV_TITLE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_FOOTER/$( echo "${AGENDAV_FOOTER}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_ENC_KEY/$( echo "${AGENDAV_ENC_KEY}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
@@ -9,8 +12,15 @@ sed -i -e "s/AGENDAV_CALDAV_PUBLIC_URL/$( echo "${AGENDAV_CALDAV_PUBLIC_URL:-$AG
 sed -i -e "s/UTC/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_LANG/$( echo "${AGENDAV_LANG}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_LOG_DIR/$( echo "${AGENDAV_LOG_DIR}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
-CONFIG_FILE="${PHP_INI_DIR}/php.ini"
+cat $CONFIG_FILE > $CONFIG_FILE_REAL
+
+CONFIG_FILE="${PHP_INI_DIR}/php.ini.tmp"
+CONFIG_FILE_REAL="${PHP_INI_DIR}/php.ini"
+
+cp $CONFIG_FILE_REAL $CONFIG_FILE
 sed -i -e "s/UTC/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
+cat $CONFIG_FILE > $CONFIG_FILE_REAL
+
 
 if [ "x$1" = 'xapache2' ]; then
 	echo "Start webserver"


### PR DESCRIPTION
I wanted to mount my settings.php, but the `sed -i` commands in `run.sh` do not work on "busy files", so this uses a temporary file which will be written to the mounted file after it is edited.
But because the `sed -i` commands were also responsible of changing the permissions of the files from ownership `root` to `www-data`[^1], we also need to correct the permissions in the Dockerfile

[^1]: Took me a while to debug this. But apparently, if you have a file owned by root in a directory owned by you, you can remove it. This is what `sed -i` essentially does, but it looks like it "changed ownership".