### PR TITLE
add a new env to set the start day of a week

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Note: **all environment variables are mandatory** and must be set via [`docker-c
 | `AGENDAV_CALDAV_SERVER`     | `https://baikal.example.com/cal.php`  |
 | `AGENDAV_CALDAV_PUBLIC_URL` | `https://baikal.example.com`          |
 | `AGENDAV_TIMEZONE`          | `UTC`, `UTC+1`, `Europe/Berlin`       |
+| `AGENDAV_WEEKSTART`         | `0` (Sunday) or `1` (Monday)          |
 | `AGENDAV_LANG`              | `en`                                  |
 | `AGENDAV_LOG_DIR`           | `/tmp/`                               |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,6 @@ services:
       - AGENDAV_TIMEZONE=UTC
       - AGENDAV_LANG=en
       - AGENDAV_LOG_DIR=/tmp/
+      - AGENDAV_WEEKSTART=1
     ports:
       - "80:8080"

--- a/pre-env.sh
+++ b/pre-env.sh
@@ -5,5 +5,6 @@ sed -i -e "s/AGENDAV_DB_NAME/$( echo "${AGENDAV_DB_NAME}" | sed -e 's/[\/}]/\\&/
 sed -i -e "s/AGENDAV_DB_USER/$( echo "${AGENDAV_DB_USER}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_DB_PASSWORD/$( echo "${AGENDAV_DB_PASSWORD}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_TIMEZONE/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
+sed -i -e "s/AGENDAV_WEEKSTART/$( echo "${AGENDAV_WEEKSTART}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 CONFIG_FILE="${PHP_INI_DIR}/php.ini"
 sed -i -e "s/AGENDAV_TIMEZONE/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,7 @@ sed -i -e "s/AGENDAV_CALDAV_PUBLIC_URL/$( echo "${AGENDAV_CALDAV_PUBLIC_URL:-$AG
 sed -i -e "s/UTC/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_LANG/$( echo "${AGENDAV_LANG}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_LOG_DIR/$( echo "${AGENDAV_LOG_DIR}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
+sed -i -e "s/AGENDAV_WEEKSTART/$( echo "${AGENDAV_WEEKSTART}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 CONFIG_FILE="${PHP_INI_DIR}/php.ini"
 sed -i -e "s/UTC/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 

--- a/settings.php
+++ b/settings.php
@@ -39,7 +39,7 @@ $app['defaults.time.format'] = '24';
  */
 $app['defaults.date_format'] = 'ymd';
 // Default first day of week. Options: 0 (Sunday), 1 (Monday)
-$app['defaults.weekstart'] = 1;
+$app['defaults.weekstart'] = 'AGENDAV_WEEKSTART';
 // Logout redirection. Optional
 $app['logout.redirection'] = '';
 // Calendar sharing


### PR DESCRIPTION
Currently, the defaults.weekstart setting is set to 1 and cannot be changed. This commit fixes that.