### PR TITLE
fix: weekstart configuration

### DIFF
--- a/pre-env.sh
+++ b/pre-env.sh
@@ -5,6 +5,5 @@ sed -i -e "s/AGENDAV_DB_NAME/$( echo "${AGENDAV_DB_NAME}" | sed -e 's/[\/}]/\\&/
 sed -i -e "s/AGENDAV_DB_USER/$( echo "${AGENDAV_DB_USER}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_DB_PASSWORD/$( echo "${AGENDAV_DB_PASSWORD}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_TIMEZONE/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
-sed -i -e "s/AGENDAV_WEEKSTART/$( echo "${AGENDAV_WEEKSTART}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 CONFIG_FILE="${PHP_INI_DIR}/php.ini"
 sed -i -e "s/AGENDAV_TIMEZONE/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ sed -i -e "s/AGENDAV_CALDAV_PUBLIC_URL/$( echo "${AGENDAV_CALDAV_PUBLIC_URL:-$AG
 sed -i -e "s/UTC/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_LANG/$( echo "${AGENDAV_LANG}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 sed -i -e "s/AGENDAV_LOG_DIR/$( echo "${AGENDAV_LOG_DIR}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
-sed -i -e "s/AGENDAV_WEEKSTART/$( echo "${AGENDAV_WEEKSTART}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
+sed -i -e "s/'AGENDAV_WEEKSTART'/$( echo "${AGENDAV_WEEKSTART}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 CONFIG_FILE="${PHP_INI_DIR}/php.ini"
 sed -i -e "s/UTC/$( echo "${AGENDAV_TIMEZONE}" | sed -e 's/[\/}]/\\&/g')/" ${CONFIG_FILE}
 


### PR DESCRIPTION
Fixes #30

- `'AGENDAV_WEEKSTART'` in settings.php was replaced to `''` during docker build, resulting in run.sh not replacing it to value specified in env. This value is (probably) not needed during build so I removed it from `pre-env.sh`
- `$app['defaults.weekstart']` should be number - I modified `run.sh` to also remove quotes around `AGENDAV_WEEKSTART` to comply with this.

Note: I only tested the image builds and runs, I did not check in browser.